### PR TITLE
Changed the interface of 'json_repair' so that it is less restrictive and more generic.

### DIFF
--- a/src/json_repair.cpp
+++ b/src/json_repair.cpp
@@ -28,7 +28,7 @@ Function: json_repair
 
 \*******************************************************************/
 
-void json_repair(std::ifstream &infile, std::ofstream &outfile)
+void json_repair(std::istream &infile, std::ostream &outfile)
 {
   std::stack<bool> elements;         // element stack (object=true)
   bool instring=false;               // within a string

--- a/src/json_repair.h
+++ b/src/json_repair.h
@@ -9,8 +9,8 @@ Author: Peter Schrammel
 #ifndef CPROVER_OUTPUT_REPAIR_JSON_REPAIR_H
 #define CPROVER_OUTPUT_REPAIR_JSON_REPAIR_H
 
-#include <fstream>
+#include <istream>
 
-void json_repair(std::ifstream &infile, std::ofstream &outfile);
+void json_repair(std::istream &infile, std::ostream &outfile);
 
 #endif // CPROVER_OUTPUT_REPAIR_JSON_REPAIR_H

--- a/src/output_repair.cpp
+++ b/src/output_repair.cpp
@@ -7,6 +7,7 @@ Author: Peter Schrammel
 \*******************************************************************/
 
 #include <iostream>
+#include <fstream>
 #include <cassert>
 
 #include "json_repair.h"

--- a/src/xml_repair.cpp
+++ b/src/xml_repair.cpp
@@ -28,7 +28,7 @@ Function: xml_repair
 
 \*******************************************************************/
 
-void xml_repair(std::ifstream &infile, std::ofstream &outfile)
+void xml_repair(std::istream &infile, std::ostream &outfile)
 {
   std::stack<std::string> tags; // tag stack
   bool intag=false;             // within a tag

--- a/src/xml_repair.h
+++ b/src/xml_repair.h
@@ -9,8 +9,8 @@ Author: Peter Schrammel
 #ifndef CPROVER_OUTPUT_REPAIR_XML_REPAIR_H
 #define CPROVER_OUTPUT_REPAIR_XML_REPAIR_H
 
-#include <fstream>
+#include <istream>
 
-void xml_repair(std::ifstream &infile, std::ofstream &outfile);
+void xml_repair(std::istream &infile, std::ostream &outfile);
 
 #endif // CPROVER_OUTPUT_REPAIR_XML_REPAIR_H


### PR DESCRIPTION
 This is useful  since there are cases where the json_file that needs to be repaired is loaded in a stringbuf (i.e std::istringstream). Applied the same change to 'xml_repair' for consistency.